### PR TITLE
Support multiple types for a property and support `NULL` type

### DIFF
--- a/src/CMPayments/SchemaValidator/BaseValidator.php
+++ b/src/CMPayments/SchemaValidator/BaseValidator.php
@@ -57,7 +57,8 @@ class BaseValidator
         self::INTEGER,
         self::NUMBER,
         self::OBJECT,
-        self::STRING
+        self::STRING,
+        self::_NULL
     ];
 
     // Valid formats for string typed items

--- a/src/CMPayments/SchemaValidator/Exceptions/ValidateSchemaException.php
+++ b/src/CMPayments/SchemaValidator/Exceptions/ValidateSchemaException.php
@@ -29,6 +29,7 @@ class ValidateSchemaException extends BaseException
     const ERROR_NO_DATA_WAS_FOUND_IN_REMOTE_SCHEMA        = 17;
     const ERROR_NO_VALID_JSON_WAS_FOUND_IN_REMOTE_SCHEMA  = 18;
     const ERROR_INPUT_IS_NOT_A_VALID_PREPOSITION          = 19;
+    const ERROR_SCHEMA_PROPERTY_TYPES_NOT_UNIQUE          = 20;
 
     protected $messages = [
         self::ERROR_SCHEMA_IS_NOT_VALID_JSON                  => 'Schema is not valid JSON',
@@ -50,6 +51,7 @@ class ValidateSchemaException extends BaseException
         self::ERROR_NO_DATA_WAS_FOUND_IN_REMOTE_SCHEMA        => 'No data found at \'%s\'',
         self::ERROR_NO_VALID_JSON_WAS_FOUND_IN_REMOTE_SCHEMA  => 'No valid JSON Schema found at \'%s\'',
         self::ERROR_INPUT_IS_NOT_A_VALID_PREPOSITION          => '\'%s\' is not a valid preposition',
+        self::ERROR_SCHEMA_PROPERTY_TYPES_NOT_UNIQUE          => '\'%s.type\' may not contain duplicate elements. Replace %s with %s',
     ];
 
     /**

--- a/src/CMPayments/SchemaValidator/Exceptions/ValidateSchemaException.php
+++ b/src/CMPayments/SchemaValidator/Exceptions/ValidateSchemaException.php
@@ -30,6 +30,7 @@ class ValidateSchemaException extends BaseException
     const ERROR_NO_VALID_JSON_WAS_FOUND_IN_REMOTE_SCHEMA  = 18;
     const ERROR_INPUT_IS_NOT_A_VALID_PREPOSITION          = 19;
     const ERROR_SCHEMA_PROPERTY_TYPES_NOT_UNIQUE          = 20;
+    const ERROR_SCHEMA_PROPERTY_VALIDATOR_DOES_NOT_EXIST  = 20;
 
     protected $messages = [
         self::ERROR_SCHEMA_IS_NOT_VALID_JSON                  => 'Schema is not valid JSON',
@@ -52,6 +53,7 @@ class ValidateSchemaException extends BaseException
         self::ERROR_NO_VALID_JSON_WAS_FOUND_IN_REMOTE_SCHEMA  => 'No valid JSON Schema found at \'%s\'',
         self::ERROR_INPUT_IS_NOT_A_VALID_PREPOSITION          => '\'%s\' is not a valid preposition',
         self::ERROR_SCHEMA_PROPERTY_TYPES_NOT_UNIQUE          => '\'%s.type\' may not contain duplicate elements. Replace %s with %s',
+        self::ERROR_SCHEMA_PROPERTY_VALIDATOR_DOES_NOT_EXIST  => 'Validator \'%s\' does not exist. Use an existing function or extend the SchemaValidator.',
     ];
 
     /**

--- a/src/CMPayments/SchemaValidator/SchemaValidator.php
+++ b/src/CMPayments/SchemaValidator/SchemaValidator.php
@@ -419,6 +419,15 @@ class SchemaValidator extends BaseValidator implements ValidatorInterface
                     );
                 }
 
+                if (is_array($schema->$property) && count($schema->$property) != count(array_unique($schema->$property))) {
+
+                    throw new ValidateSchemaException(
+                        ValidateSchemaException::ERROR_SCHEMA_PROPERTY_TYPES_NOT_UNIQUE,
+                        [$path, str_replace('"', "'", json_encode($schema->$property)), str_replace('"', "'", json_encode(array_unique($schema->$property)))]
+                    );
+
+                }
+
                 // check if a $property' value must match a list of predefined values
                 $this->validateSchemaPropertyValue($schema, $property, $path);
             }

--- a/src/CMPayments/SchemaValidator/Validators/ErrorTrait.php
+++ b/src/CMPayments/SchemaValidator/Validators/ErrorTrait.php
@@ -85,8 +85,8 @@ trait ErrorTrait
      */
     public function getPreposition($type)
     {
-        $type = ((array) $type)[0];
-        $type = strtolower($type);
+        $types = (array) $type;
+        $type = strtolower($types[0]);
 
         if (!isset($this->prepositions[$type])) {
 

--- a/src/CMPayments/SchemaValidator/Validators/ErrorTrait.php
+++ b/src/CMPayments/SchemaValidator/Validators/ErrorTrait.php
@@ -85,6 +85,7 @@ trait ErrorTrait
      */
     public function getPreposition($type)
     {
+        $type = ((array) $type)[0];
         $type = strtolower($type);
 
         if (!isset($this->prepositions[$type])) {

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -22,7 +22,9 @@ class DataTest extends BaseTest
             '{"type": "string"}'                                                                                   => 'test123',
             '{"type": "string", "enum": ["test"]}'                                                                 => 'test',
             '{"type": "array","items": {"type": "string"}}'                                                        => ['test123'],
-            '{"type": "object", "properties": {"zipcode": {"type": "string", "pattern" : "[0-9]{4}[a-zA-Z]{2}"}}}' => json_decode('{"zipcode" : "48118EW"}')
+            '{"type": ["string", "null"]}'                                                                         => 'test213',
+            '{"type": ["null", "string"]}'                                                                         => NULL,
+            '{"type": "object", "properties": {"zipcode": {"type": "string", "pattern" : "[0-9]{4}[a-zA-Z]{2}"}}}' => json_decode('{"zipcode" : "48118EW"}'),
         ];
 
         return $this->provideArrayForValidation($valid);

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -103,7 +103,10 @@ class SchemaTest extends BaseTest
             /** @TODO; Write test */
             ValidateSchemaException::ERROR_INPUT_IS_NOT_A_VALID_PREPOSITION          => [
 
-            ]
+            ],
+            ValidateSchemaException::ERROR_SCHEMA_PROPERTY_TYPES_NOT_UNIQUE          => [
+                json_decode('{"type": "object", "properties": {"id": {"type": ["number", "number"]}}, "required": true}'),
+            ],
         ];
 
         $this->executeExceptionValidation($exceptions);

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -58,7 +58,8 @@ class SchemaTest extends BaseTest
                 json_decode('{"type": "object", "properties": {"id": {"type": "string", "format": "non-existent"}}}')
             ],
             ValidateSchemaException::ERROR_SCHEMA_PROPERTY_TYPE_NOT_VALID            => [
-                json_decode('{"type": "object", "properties": {"id": {"type": "string", "minLength": "1"}}}')
+                json_decode('{"type": "object", "properties": {"id": {"type": "string", "minLength": "1"}}}'),
+                json_decode('{"type": "object", "properties": {"id": {"type": ["string", null]}}}'),
             ],
             ValidateSchemaException::ERROR_SCHEMA_MAX_PROPERTY_CANNOT_NOT_BE_ZERO    => [
                 json_decode('{"type": "object", "properties": {"id": {"type": "string", "maxLength": 0}}}'),


### PR DESCRIPTION
Properties can be defined to allow multiple types, for details see
http://json-schema.org/latest/json-schema-validation.html#rfc.section.5.21

To support this, we treat the schema type as an array where applicable.

In addition, this change adds support for `NULL` as a type.
See http://json-schema.org/latest/json-schema-core.html#rfc.section.4.2